### PR TITLE
Fix file path resolution for unloaded projects

### DIFF
--- a/src/CodingWithCalvin.OpenInNotepadPlusPlus/Helpers/ProjectHelpers.cs
+++ b/src/CodingWithCalvin.OpenInNotepadPlusPlus/Helpers/ProjectHelpers.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using EnvDTE;
 using EnvDTE80;
 using Microsoft.VisualStudio.Shell;
@@ -7,6 +8,8 @@ namespace CodingWithCalvin.OpenInNotepadPlusPlus.Helpers
 {
     internal static class ProjectHelpers
     {
+        private const string UnloadedProjectGuid = "{67294A52-A4F0-11D2-AA88-00C04F688DDE}";
+
         public static string GetSelectedPath(DTE2 dte)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
@@ -21,11 +24,37 @@ namespace CodingWithCalvin.OpenInNotepadPlusPlus.Helpers
                     case ProjectItem projectItem:
                         return projectItem.FileNames[1];
                     case Project project:
-                        return project.FullName;
+                        return GetProjectPath(project, dte.Solution);
                     case Solution solution:
                         return solution.FullName;
                 }
             }
+            return null;
+        }
+
+        private static string GetProjectPath(Project project, Solution solution)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            bool isUnloaded = project.Kind.Equals(UnloadedProjectGuid, StringComparison.OrdinalIgnoreCase);
+
+            if (!isUnloaded)
+            {
+                return project.FullName;
+            }
+
+            // For unloaded projects, FullName is empty but UniqueName contains
+            // the relative path from the solution directory
+            if (!string.IsNullOrEmpty(project.UniqueName) && !string.IsNullOrEmpty(solution?.FullName))
+            {
+                var solutionDirectory = Path.GetDirectoryName(solution.FullName);
+                var projectPath = Path.Combine(solutionDirectory, project.UniqueName);
+                if (File.Exists(projectPath))
+                {
+                    return projectPath;
+                }
+            }
+
             return null;
         }
     }


### PR DESCRIPTION
## Summary
- Fixes #13
- Detects unloaded projects by checking `project.Kind` against the unloaded project GUID (`{67294A52-A4F0-11D2-AA88-00C04F688DDE}`)
- Falls back to constructing the path from the solution directory and `project.UniqueName` when a project is unloaded

## Test plan
- [ ] Load a solution with multiple projects
- [ ] Unload one of the projects (right-click -> Unload Project)
- [ ] Right-click on the unloaded project and select "Open in Notepad++"
- [ ] Verify the project file opens correctly in Notepad++