### PR TITLE
Fix nested path resolution failure

### DIFF
--- a/src/CodingWithCalvin.OpenInNotepadPlusPlus/Commands/OpenExecutableCommand.cs
+++ b/src/CodingWithCalvin.OpenInNotepadPlusPlus/Commands/OpenExecutableCommand.cs
@@ -72,7 +72,6 @@ namespace CodingWithCalvin.OpenInNotepadPlusPlus.Commands
         {
             var startInfo = new ProcessStartInfo
             {
-                WorkingDirectory = selectedFilePath,
                 FileName = $"\"{executablePath}\"",
                 Arguments = $"\"{selectedFilePath}\"",
                 CreateNoWindow = true,


### PR DESCRIPTION
## Summary
- Fixes #5
- Removes `WorkingDirectory` from `ProcessStartInfo` as it was incorrectly being set to a file path instead of a directory path
- This caused failures when opening files in deeply nested paths

## Root Cause
`ProcessStartInfo.WorkingDirectory` expects a directory path, but `selectedFilePath` is a file path (e.g., `C:\...\file.h`). For deeply nested or long paths, this would cause the process to fail, resulting in "Couldn't resolve the folder" error.

## Test plan
- [ ] Open a solution with deeply nested files (5+ levels deep)
- [ ] Right-click on a file in a nested path and select "Open in Notepad++"
- [ ] Verify the file opens correctly in Notepad++