### PR TITLE
fix(build): use SetVsixVersion parameter and standardize output paths

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,17 +35,17 @@ jobs:
       shell: pwsh
 
     - name: 3. Building Project
-      run: dotnet build src/CodingWithCalvin.OpenInNotepadPlusPlus/CodingWithCalvin.OpenInNotepadPlusPlus.csproj -c Release -p:Version=${{ steps.version.outputs.version }}
+      run: dotnet build src/CodingWithCalvin.OpenInNotepadPlusPlus/CodingWithCalvin.OpenInNotepadPlusPlus.csproj -c Release -p:SetVsixVersion=${{ steps.version.outputs.version }}
 
     - name: 4. Create Information File
       uses: jsdaniell/create-json@v1.2.3
       with:
-        name: 'src/CodingWithCalvin.OpenInNotepadPlusPlus/bin/Release/net48/CodingWithCalvin.OpenInNotepadPlusPlus.info'
+        name: 'src/CodingWithCalvin.OpenInNotepadPlusPlus/bin/Release/CodingWithCalvin.OpenInNotepadPlusPlus.info'
         json: '{"sha":"${{ github.sha }}", "version":"${{ steps.version.outputs.version }}"}'
 
     - name: 5. Publishing Build Artifact
       uses: actions/upload-artifact@v4
       with:
         path: |
-          src/CodingWithCalvin.OpenInNotepadPlusPlus/bin/Release/net48/CodingWithCalvin.OpenInNotepadPlusPlus.info
-          src/CodingWithCalvin.OpenInNotepadPlusPlus/bin/Release/net48/CodingWithCalvin.OpenInNotepadPlusPlus.vsix
+          src/CodingWithCalvin.OpenInNotepadPlusPlus/bin/Release/CodingWithCalvin.OpenInNotepadPlusPlus.info
+          src/CodingWithCalvin.OpenInNotepadPlusPlus/bin/Release/CodingWithCalvin.OpenInNotepadPlusPlus.vsix

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
         id: download-artifact
         uses: dawidd6/action-download-artifact@v6
         with:
-          workflow: release_build_and_deploy.yml
+          workflow: build.yml
           workflow_conclusion: success
 
       - name: 2. Parse Artifact Manifest

--- a/src/CodingWithCalvin.OpenInNotepadPlusPlus/CodingWithCalvin.OpenInNotepadPlusPlus.csproj
+++ b/src/CodingWithCalvin.OpenInNotepadPlusPlus/CodingWithCalvin.OpenInNotepadPlusPlus.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>CodingWithCalvin.OpenInNotepadPlusPlus</RootNamespace>
     <AssemblyName>CodingWithCalvin.OpenInNotepadPlusPlus</AssemblyName>
     <LangVersion>latest</LangVersion>
+    <OutputPath>bin/$(Configuration)/</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">


### PR DESCRIPTION
## Summary
- Change `-p:Version` to `-p:SetVsixVersion` for correct VSIX versioning
- Add `OutputPath=bin/$(Configuration)/` to .csproj for consistent output paths
- Update artifact paths from `bin/Release/net48/` to `bin/Release/`
- Rename build workflow from `release_build_and_deploy.yml` to `build.yml`
- Update publish workflow to reference renamed build.yml

## Test plan
- [ ] Verify build workflow runs successfully
- [ ] Verify VSIX version is set correctly
- [ ] Verify artifacts are uploaded from correct path