### PR TITLE
chore: add path filters and use shared publish workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,49 +16,9 @@ on:
       - '*.slnx'
       - '.github/workflows/build.yml'
 
-env:
-  PROJECT_PATH: src/CodingWithCalvin.OpenInNotepadPlusPlus/CodingWithCalvin.OpenInNotepadPlusPlus.csproj
-  OUTPUT_PATH: src/CodingWithCalvin.OpenInNotepadPlusPlus/bin/Release
-  INFO_FILE: CodingWithCalvin.OpenInNotepadPlusPlus.info
-  VSIX_FILE: CodingWithCalvin.OpenInNotepadPlusPlus.vsix
-
 jobs:
   build:
-    runs-on: windows-latest
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: 1. Generate Version
-      id: version
-      run: |
-        $year = (Get-Date).Year
-        $month = (Get-Date).Month
-        $day = (Get-Date).Day
-        $version = "$year.$month.$day.${{ github.run_number }}"
-        echo "version=$version" >> $env:GITHUB_OUTPUT
-      shell: pwsh
-
-    - name: 2. Inject Honeycomb API Key
-      run: |
-        $file = 'src/CodingWithCalvin.OpenInNotepadPlusPlus/HoneycombConfig.cs'
-        $content = Get-Content $file -Raw
-        $content = $content -replace 'PLACEHOLDER', '${{ secrets.HONEYCOMB_API_KEY }}'
-        Set-Content $file $content
-      shell: pwsh
-
-    - name: 3. Build Project
-      run: dotnet build ${{ env.PROJECT_PATH }} -c Release -p:SetVsixVersion=${{ steps.version.outputs.version }}
-
-    - name: 4. Create Information File
-      uses: jsdaniell/create-json@v1.2.3
-      with:
-        name: '${{ env.OUTPUT_PATH }}/${{ env.INFO_FILE }}'
-        json: '{"sha":"${{ github.sha }}", "version":"${{ steps.version.outputs.version }}"}'
-
-    - name: 5. Upload Artifact
-      uses: actions/upload-artifact@v4
-      with:
-        path: |
-          ${{ env.OUTPUT_PATH }}/${{ env.INFO_FILE }}
-          ${{ env.OUTPUT_PATH }}/${{ env.VSIX_FILE }}
+    uses: CodingWithCalvin/.github/.github/workflows/vsix-build.yml@main
+    with:
+      extension-name: OpenInNotepadPlusPlus
+    secrets: inherit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,15 +1,29 @@
-name: 'Build and Deploy'
+name: Build
 
 on:
   workflow_dispatch:
   pull_request:
     types: [opened, reopened]
+    paths:
+      - 'src/**'
+      - '*.slnx'
+      - '.github/workflows/build.yml'
   push:
     branches:
       - main
+    paths:
+      - 'src/**'
+      - '*.slnx'
+      - '.github/workflows/build.yml'
+
+env:
+  PROJECT_PATH: src/CodingWithCalvin.OpenInNotepadPlusPlus/CodingWithCalvin.OpenInNotepadPlusPlus.csproj
+  OUTPUT_PATH: src/CodingWithCalvin.OpenInNotepadPlusPlus/bin/Release
+  INFO_FILE: CodingWithCalvin.OpenInNotepadPlusPlus.info
+  VSIX_FILE: CodingWithCalvin.OpenInNotepadPlusPlus.vsix
 
 jobs:
-  Release-Build-and-Deploy:
+  build:
     runs-on: windows-latest
 
     steps:
@@ -23,7 +37,6 @@ jobs:
         $day = (Get-Date).Day
         $version = "$year.$month.$day.${{ github.run_number }}"
         echo "version=$version" >> $env:GITHUB_OUTPUT
-        Write-Host "Generated version: $version"
       shell: pwsh
 
     - name: 2. Inject Honeycomb API Key
@@ -34,18 +47,18 @@ jobs:
         Set-Content $file $content
       shell: pwsh
 
-    - name: 3. Building Project
-      run: dotnet build src/CodingWithCalvin.OpenInNotepadPlusPlus/CodingWithCalvin.OpenInNotepadPlusPlus.csproj -c Release -p:SetVsixVersion=${{ steps.version.outputs.version }}
+    - name: 3. Build Project
+      run: dotnet build ${{ env.PROJECT_PATH }} -c Release -p:SetVsixVersion=${{ steps.version.outputs.version }}
 
     - name: 4. Create Information File
       uses: jsdaniell/create-json@v1.2.3
       with:
-        name: 'src/CodingWithCalvin.OpenInNotepadPlusPlus/bin/Release/CodingWithCalvin.OpenInNotepadPlusPlus.info'
+        name: '${{ env.OUTPUT_PATH }}/${{ env.INFO_FILE }}'
         json: '{"sha":"${{ github.sha }}", "version":"${{ steps.version.outputs.version }}"}'
 
-    - name: 5. Publishing Build Artifact
+    - name: 5. Upload Artifact
       uses: actions/upload-artifact@v4
       with:
         path: |
-          src/CodingWithCalvin.OpenInNotepadPlusPlus/bin/Release/CodingWithCalvin.OpenInNotepadPlusPlus.info
-          src/CodingWithCalvin.OpenInNotepadPlusPlus/bin/Release/CodingWithCalvin.OpenInNotepadPlusPlus.vsix
+          ${{ env.OUTPUT_PATH }}/${{ env.INFO_FILE }}
+          ${{ env.OUTPUT_PATH }}/${{ env.VSIX_FILE }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,84 +8,12 @@ permissions:
   actions: read
 
 jobs:
-  changelog:
-    name: Generate Changelog
-    uses: CodingWithCalvin/.github/.github/workflows/generate-changelog.yml@main
-    secrets: inherit
-
   publish:
-    needs: changelog
-    runs-on: windows-latest
-    outputs:
-      version: ${{ steps.artifact_manifest.outputs.version }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: 1. Download artifact
-        id: download-artifact
-        uses: dawidd6/action-download-artifact@v6
-        with:
-          workflow: build.yml
-          workflow_conclusion: success
-
-      - name: 2. Parse Artifact Manifest
-        id: artifact_manifest
-        uses: ActionsTools/read-json-action@main
-        with:
-          file_path: ./artifact/CodingWithCalvin.OpenInNotepadPlusPlus.info
-
-      - name: 3. Create Tag & Release
-        uses: ncipollo/release-action@v1.14.0
-        with:
-          artifacts: ./artifact/CodingWithCalvin.OpenInNotepadPlusPlus.vsix
-          body: ${{ needs.changelog.outputs.changelog }}
-          makeLatest: true
-          commit: ${{ steps.artifact_manifest.outputs.sha }}
-          tag: ${{ steps.artifact_manifest.outputs.version }}
-
-      - name: 4. Publish Release to Marketplace
-        if: success()
-        uses: CodingWithCalvin/GHA-VSMarketplacePublisher@v1
-        with:
-          marketplace-pat: ${{ secrets.VS_PAT }}
-          publish-manifest-path: ./resources/extension.manifest.json
-          vsix-path: ./artifact/CodingWithCalvin.OpenInNotepadPlusPlus.vsix
-
-  notify-bluesky:
-    name: Post to BlueSky
-    needs: publish
-    uses: CodingWithCalvin/.github/.github/workflows/bluesky-post.yml@main
+    uses: CodingWithCalvin/.github/.github/workflows/vsix-publish.yml@main
     with:
-      post_text: |
-        🚀 Open in Notepad++ v${{ needs.publish.outputs.version }} for #VisualStudio has been released!
-
-        📝 [Release Notes](https://github.com/${{ github.repository }}/releases/tag/${{ needs.publish.outputs.version }})
-        🛒 [Marketplace](https://marketplace.visualstudio.com/items?itemName=CodingWithCalvin.VS-OpenInNotepadPlusPlus)
-
-        #dotnet #visualstudio #vsix #notepadplusplus
-      embed_url: https://marketplace.visualstudio.com/items?itemName=CodingWithCalvin.VS-OpenInNotepadPlusPlus
-      embed_title: "Open in Notepad++ v${{ needs.publish.outputs.version }}"
-      embed_description: "Visual Studio extension to open files in Notepad++"
-    secrets:
-      BLUESKY_USERNAME: ${{ secrets.BLUESKY_USERNAME }}
-      BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}
-
-  notify-linkedin:
-    name: Post to LinkedIn
-    needs: publish
-    uses: CodingWithCalvin/.github/.github/workflows/linkedin-post.yml@main
-    with:
-      post_text: |
-        🚀 Open in Notepad++ v${{ needs.publish.outputs.version }} for Visual Studio has been released!
-
-        📝 Release Notes: https://github.com/${{ github.repository }}/releases/tag/${{ needs.publish.outputs.version }}
-        🛒 Marketplace: https://marketplace.visualstudio.com/items?itemName=CodingWithCalvin.VS-OpenInNotepadPlusPlus
-
-        #dotnet #visualstudio #vsix #notepadplusplus
-      article_url: https://marketplace.visualstudio.com/items?itemName=CodingWithCalvin.VS-OpenInNotepadPlusPlus
-      article_title: "Open in Notepad++ v${{ needs.publish.outputs.version }}"
-      article_description: "Visual Studio extension to open files in Notepad++"
-    secrets:
-      LINKEDIN_ACCESS_TOKEN: ${{ secrets.LINKEDIN_ACCESS_TOKEN }}
-      LINKEDIN_CLIENT_ID: ${{ secrets.LINKEDIN_CLIENT_ID }}
+      extension-name: OpenInNotepadPlusPlus
+      display-name: 'Open in Notepad++'
+      marketplace-id: CodingWithCalvin.VS-OpenInNotepadPlusPlus
+      description: 'Visual Studio extension to open files in Notepad++'
+      hashtags: '#notepadplusplus'
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Add path filters to build.yml (only triggers on src/**, *.slnx, build.yml changes)
- Use env variables for cleaner file path management
- Migrate publish.yml to use shared vsix-publish.yml workflow

Note: build.yml retains custom steps for Honeycomb API key injection, so it can't use the shared build workflow.

## Test plan
- [ ] Verify build doesn't trigger on .gitignore or README changes
- [ ] Verify publish workflow works correctly