### PR TITLE
chore(deps): upgrade VsixSdk to 0.4.0 and add VSSDK.BuildTools

### DIFF
--- a/src/CodingWithCalvin.OpenInNotepadPlusPlus.slnx
+++ b/src/CodingWithCalvin.OpenInNotepadPlusPlus.slnx
@@ -1,4 +1,9 @@
 <Solution>
+  <Configurations>
+    <Configuration Name="Debug" />
+    <Configuration Name="Release" />
+    <Platform Name="AnyCPU" />
+  </Configurations>
   <Folder Name="/Solution Items/">
     <File Path="../resources/extension.manifest.json" />
     <File Path="../.github/workflows/publish.yml" />

--- a/src/CodingWithCalvin.OpenInNotepadPlusPlus/CodingWithCalvin.OpenInNotepadPlusPlus.csproj
+++ b/src/CodingWithCalvin.OpenInNotepadPlusPlus/CodingWithCalvin.OpenInNotepadPlusPlus.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="CodingWithCalvin.VsixSdk/0.3.0">
+﻿<Project Sdk="CodingWithCalvin.VsixSdk/0.4.0">
 
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
@@ -8,12 +8,9 @@
     <OutputPath>bin/$(Configuration)/</OutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-    <DeployExtension>True</DeployExtension>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.14.40265" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.*" PrivateAssets="all" />
 	<PackageReference Include="CodingWithCalvin.Otel4Vsix" Version="0.2.2" />
   </ItemGroup>
 

--- a/src/CodingWithCalvin.OpenInNotepadPlusPlus/Properties/launchSettings.json
+++ b/src/CodingWithCalvin.OpenInNotepadPlusPlus/Properties/launchSettings.json
@@ -1,9 +1,0 @@
-{
-  "profiles": {
-    "Start Experimental Instance": {
-      "commandName": "Executable",
-      "executablePath": "C:\\Program Files\\Microsoft Visual Studio\\18\\Community\\Common7\\IDE\\devenv.exe",
-      "commandLineArgs": "/rootSuffix Exp"
-    }
-  }
-}


### PR DESCRIPTION
## Summary
- Upgrade CodingWithCalvin.VsixSdk from 0.3.0 to 0.4.0
- Add Microsoft.VSSDK.BuildTools 17.* package reference
- Remove redundant DeployExtension property (SDK handles this)
- Remove launchSettings.json (SDK handles this)

## Test plan
- [ ] Verify build succeeds
- [ ] Verify VSIX is created correctly