### PR TITLE
ci(workflow): remove social media inputs from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,4 @@ jobs:
       extension-name: OpenInNotepadPlusPlus
       display-name: 'Open in Notepad++'
       marketplace-id: CodingWithCalvin.VS-OpenInNotepadPlusPlus
-      description: 'Visual Studio extension to open files in Notepad++'
-      hashtags: '#notepadplusplus'
     secrets: inherit


### PR DESCRIPTION
## Summary
- Remove social media inputs (`description`, `hashtags`) from publish workflow that are no longer used by the reusable vsix-publish workflow

## Test plan
- [ ] Verify publish workflow still works correctly